### PR TITLE
fix: address crashes in recycler view

### DIFF
--- a/android/example/app.js
+++ b/android/example/app.js
@@ -1,7 +1,4 @@
-var IOS = (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad');
-var ANDROID = (Ti.Platform.osname === 'android');
-var UI = require('ui');
-var Map = require('ti.map');
+const Map = require('ti.map');
 
 //=====================================================================
 // Rows
@@ -14,19 +11,4 @@ var rows = [
     require('tests/drawing')
 ];
 
-if (IOS) {
-    rows.push(require('tests/camera'));
-    rows.push(require('tests/properties'));
-}
-
-if (ANDROID && Map.isGooglePlayServicesAvailable() != Map.SUCCESS) {
-        alert ("Google Play Services is not installed/updated/available");
-} else {
-    startUI();
-}
-
-function startUI() {
-    UI.init(rows, function(e) {
-        rows[e.index].run && rows[e.index].run(UI, Map);
-    });
-}
+win.open();

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Tue Oct 25 11:45:14 CEST 2022
+sdk.dir=/Users/janvennemann/Library/Android/sdk

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Oct 25 11:45:14 CEST 2022
-sdk.dir=/Users/janvennemann/Library/Android/sdk

--- a/android/platform/android/res/layout/ti_map.xml
+++ b/android/platform/android/res/layout/ti_map.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/android/platform/android/res/layout/ti_map_raw.xml
+++ b/android/platform/android/res/layout/ti_map_raw.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.gms.maps.MapView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:map="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/lite_raw_map"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/android/platform/android/res/layout/ti_map_raw.xml
+++ b/android/platform/android/res/layout/ti_map_raw.xml
@@ -4,4 +4,5 @@
     xmlns:map="http://schemas.android.com/apk/res-auto"
     android:id="@+id/lite_raw_map"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    map:liteMode="true" />

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -86,6 +86,7 @@ public class MapModule extends KrollModule implements OnMapsSdkInitializedCallba
 	public static final String PROPERTY_INDOOR_ENABLED = "indoorEnabled";
 	public static final String PROPERTY_PLACE_ID = "placeID";
 	public static final String PROPERTY_DESELECTED = "deselected";
+	public static final String PROPERTY_LITE_MODE = "liteMode";
 
 	@Kroll.constant
 	public static final int NORMAL_TYPE = GoogleMap.MAP_TYPE_NORMAL;

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -16,15 +16,18 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.location.Location;
 import android.os.Build;
+import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMapOptions;
+import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.CameraPosition;
@@ -50,12 +53,16 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.view.TiUIFragment;
+import org.appcelerator.titanium.view.TiUIView;
+import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -63,7 +70,7 @@ import org.json.JSONTokener;
 import ti.map.Shape.Boundary;
 import ti.map.Shape.IShape;
 
-public class TiUIMapView extends TiUIFragment
+public class TiUIMapView extends TiUIView
 	implements GoogleMap.OnMarkerClickListener, GoogleMap.OnMapClickListener, GoogleMap.OnMarkerDragListener,
 			   GoogleMap.OnInfoWindowClickListener, GoogleMap.InfoWindowAdapter, GoogleMap.OnMapLongClickListener,
 			   GoogleMap.OnMapLoadedCallback, OnMapReadyCallback, GoogleMap.OnCameraMoveStartedListener,
@@ -74,6 +81,7 @@ public class TiUIMapView extends TiUIFragment
 
 	public static final String DEFAULT_COLLECTION_ID = "defaultCollection";
 	private static final String TAG = "TiUIMapView";
+	private static final String MAP_FRAGMENT_TAG = "map";
 	private GoogleMap map;
 	protected boolean animate = false;
 	protected boolean preLayout = true;
@@ -88,15 +96,74 @@ public class TiUIMapView extends TiUIFragment
 	private ClusterManager<TiMarker> mClusterManager;
 	private MarkerManager mMarkerManager;
 
+	private SupportMapFragment mapFragment;
+
+	private MapView mapView;
+
+	public boolean rawMap = false;
+
+	public boolean isReady = false;
+
 	public TiUIMapView(final TiViewProxy proxy, Activity activity)
 	{
-		super(proxy, activity);
+		super(proxy);
 		timarkers = new ArrayList<TiMarker>();
 		currentCircles = new ArrayList<CircleProxy>();
 		currentPolygons = new ArrayList<PolygonProxy>();
 		currentPolylines = new ArrayList<PolylineProxy>();
 		currentImageOverlays = new ArrayList<ImageOverlayProxy>();
 		proxy.setProperty(MapModule.PROPERTY_INDOOR_ENABLED, true);
+
+		var rawMap = TiConvert.toBoolean(proxy.getProperty("rawMap"), false);
+
+		try {
+			var inflater = activity.getLayoutInflater();
+			var view = inflater.inflate(TiRHelper.getResource(rawMap ? "layout.ti_map_raw" : "layout.ti_map"), null);
+			if (rawMap) {
+				mapView = (MapView) view;
+			}
+			setNativeView(view);
+		} catch (TiRHelper.ResourceNotFoundException e) {
+			Log.d("TiUIMapView", "Failed to load layout for TiUIMapView");
+		}
+
+		if (rawMap) {
+			Log.d(TAG, "new TiUIMapView raw map");
+			mapView.onCreate(null);
+			mapView.getMapAsync(this);
+		} else {
+			Log.d(TAG, "new TiUIMapView fragment");
+
+			var sfm = ((AppCompatActivity)activity).getSupportFragmentManager();
+			mapFragment = (SupportMapFragment)sfm.findFragmentByTag(MAP_FRAGMENT_TAG);
+
+			if (mapFragment == null) {
+				// Create a SupportMapFragment with our options
+				var zOrderOnTop = TiConvert.toBoolean(proxy.getProperty(MapModule.PROPERTY_ZORDER_ON_TOP), false);
+				GoogleMapOptions gOptions = new GoogleMapOptions();
+				gOptions.zOrderOnTop(zOrderOnTop);
+				var liteMode = TiConvert.toBoolean(proxy.getProperty(MapModule.PROPERTY_LITE_MODE), false);
+				if (liteMode) {
+					gOptions.liteMode(true);
+				}
+				mapFragment = SupportMapFragment.newInstance(gOptions);
+
+				// Add it using a FragmentTransaction
+				sfm.beginTransaction()
+						.setReorderingAllowed(true)
+						.add(R.id.fragment_container_view, mapFragment, MAP_FRAGMENT_TAG)
+						.commit();
+			}
+
+			mapFragment.getMapAsync(this);
+		}
+	}
+
+	public void initializeMap() {
+		if (mapView != null) {
+			mapView.onCreate(null);
+			mapView.getMapAsync(this);
+		}
 	}
 
 	/**
@@ -118,27 +185,6 @@ public class TiUIMapView extends TiUIFragment
 			for (int i = 0; i < viewGroup.getChildCount(); i++) {
 				setBackgroundTransparent(viewGroup.getChildAt(i));
 			}
-		}
-	}
-
-	@Override
-	protected Fragment createFragment()
-	{
-		if (proxy == null) {
-			Fragment map = SupportMapFragment.newInstance();
-			if (map instanceof SupportMapFragment) {
-				((SupportMapFragment) map).getMapAsync(this);
-			}
-			return map;
-		} else {
-			boolean zOrderOnTop = TiConvert.toBoolean(proxy.getProperty(MapModule.PROPERTY_ZORDER_ON_TOP), false);
-			GoogleMapOptions gOptions = new GoogleMapOptions();
-			gOptions.zOrderOnTop(zOrderOnTop);
-			Fragment map = SupportMapFragment.newInstance(gOptions);
-			if (map instanceof SupportMapFragment) {
-				((SupportMapFragment) map).getMapAsync(this);
-			}
-			return map;
 		}
 	}
 
@@ -212,7 +258,7 @@ public class TiUIMapView extends TiUIFragment
 		processPreloadCircles();
 		processPreloadPolylines();
 		processOverlaysList();
-		
+
 		map.setOnMarkerClickListener(mMarkerManager);
 		map.setOnMapClickListener(this);
 		map.setOnCameraIdleListener(this);
@@ -226,10 +272,10 @@ public class TiUIMapView extends TiUIFragment
 		map.setOnMyLocationChangeListener(this);
 		map.setOnPoiClickListener(this);
 		map.setOnPolylineClickListener(this);
-		
+
 		mClusterManager.setOnClusterClickListener(this);
 		mClusterManager.setOnClusterItemClickListener(this);
-		
+
 		((ViewProxy) proxy).clearPreloadObjects();
 
 		fireEvent(MapModule.EVENT_READY, new KrollDict());
@@ -248,6 +294,13 @@ public class TiUIMapView extends TiUIFragment
 
 	public void processMapProperties(KrollDict d)
 	{
+		if (d.containsKey("rawMap")) {
+			this.rawMap = d.getBoolean("rawMap");
+			this.liteMode = true;
+		}
+		if (d.containsKey(MapModule.PROPERTY_LITE_MODE)) {
+			this.liteMode = d.getBoolean(MapModule.PROPERTY_LITE_MODE);
+		}
 		if (d.containsKey(TiC.PROPERTY_USER_LOCATION)) {
 			setUserLocationEnabled(TiConvert.toBoolean(d, TiC.PROPERTY_USER_LOCATION, false));
 		}
@@ -786,7 +839,7 @@ public class TiUIMapView extends TiUIFragment
 		r.processOptions();
 		r.setRoute( createPolyLine(r.getOptions()) );
 	}
-	
+
 	private Polyline createPolyLine(PolylineOptions polylineOptions) {
 		Polyline polyline = map.addPolyline(polylineOptions);
 		polyline.setClickable(true);
@@ -976,10 +1029,10 @@ public class TiUIMapView extends TiUIFragment
 		if (map == null) {
 		  return false;
 		}
-		
+
 		LatLngBounds mapBounds = map.getProjection().getVisibleRegion().latLngBounds;
 		LatLng nativeCoordinate = new LatLng(coordinate.getDouble("latitude").doubleValue(), coordinate.getDouble("longitude").doubleValue());
-		
+
 		return mapBounds.contains(nativeCoordinate);
 	}
 
@@ -1366,7 +1419,7 @@ public class TiUIMapView extends TiUIFragment
 
 	// Intercept the touch event to find out the correct clicksource if clicking
 	// on the info window.
-	@Override
+	// @Override
 	protected boolean interceptTouchEvent(MotionEvent ev)
 	{
 		if (ev.getAction() == MotionEvent.ACTION_UP && selectedAnnotation != null) {
@@ -1443,7 +1496,7 @@ public class TiUIMapView extends TiUIFragment
 	@Override
 	public void onPolylineClick(Polyline polyline) {
 		final String id = polyline.getId();
-		
+
 		// find the proxy for this polyline
 		PolylineProxy polylineProxy = null;
 		for (PolylineProxy tempPolylineProxy : currentPolylines) {
@@ -1452,12 +1505,12 @@ public class TiUIMapView extends TiUIFragment
 				break;
 			}
 		}
-		
+
 		KrollDict d = new KrollDict();
 		d.put(TiC.EVENT_PROPERTY_CLICKSOURCE, MapModule.PROPERTY_POLYLINE);
 		d.put(TiC.PROPERTY_ANNOTATION, false);
 		d.put("overlay", polylineProxy);
-		
+
 		d.put(MapModule.PROPERTY_MAP, proxy);
 		d.put(TiC.PROPERTY_TYPE, TiC.EVENT_CLICK);
 		d.put(TiC.PROPERTY_SOURCE, polylineProxy);

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -103,8 +103,6 @@ public class TiUIMapView extends TiUIView
 
 	public boolean rawMap = false;
 
-	public boolean isReady = false;
-
 	public TiUIMapView(final TiViewProxy proxy, Activity activity)
 	{
 		super(proxy);

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -17,6 +17,7 @@ import org.appcelerator.kroll.common.AsyncResult;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.common.TiMessenger;
 import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
@@ -334,11 +335,34 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 				result.setResult(Boolean.valueOf(handleContainsCoordinate((KrollDict)result.getArg())));
 				return true;
 			}
-		  
+
 			default: {
 				return super.handleMessage(msg);
 			}
 		}
+	}
+
+	@Kroll.method
+	public void clear() {
+		var view = (TiUIMapView)peekView();
+		if (view.getMap() != null) {
+			view.getMap().clear();
+			view.getMap().setMapType(GoogleMap.MAP_TYPE_NONE);
+		}
+	}
+
+	@Kroll.method
+	public void initializeMap() {
+		var view = (TiUIMapView)peekView();
+		if (view != null) {
+			view.initializeMap();
+		}
+	}
+
+	@Kroll.method
+	public boolean isReady() {
+		var view = (TiUIMapView)peekView();
+		return view != null && view.isReady;
 	}
 
 	@Kroll.method
@@ -1226,7 +1250,7 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	{
 	  return handleContainsCoordinate(coordinate);
 	}
-	
+
 	private boolean handleContainsCoordinate(KrollDict coordinate) {
 	  TiUIView view = peekView();
 	  if ((view instanceof TiUIMapView)) {

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -360,12 +360,6 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	}
 
 	@Kroll.method
-	public boolean isReady() {
-		var view = (TiUIMapView)peekView();
-		return view != null && view.isReady;
-	}
-
-	@Kroll.method
 	public void addAnnotation(AnnotationProxy annotation)
 	{
 		// Update the JS object


### PR DESCRIPTION
Fix for ANR crashes when using the map inside the recycler view. This includes the following changes:

- Refactor to [FragmentContainerView](https://developer.android.com/reference/androidx/fragment/app/FragmentContainerView) to be able to subclass from `TiUIView` instead of `TiUIFragment`. This is required to be able to load the map in different modes.
- Cherry picked the `liteMode` PR from Chris Williams
- New `rawMap` mode, which loads a [MapView](https://developers.google.com/maps/documentation/android-sdk/reference/com/google/android/libraries/maps/MapView) instead of a fragment and enables `liteMode`. This is intended for usages inside recycler view, where no interactivity is needed and the only lifecycle method  that is required is `onCreate`.