### PR TITLE
fix: wrap MapView in a container, disable accessibility

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.1.0
+version: 5.1.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library
@@ -15,5 +15,5 @@ name: map
 moduleid: ti.map
 guid: f0d8fd44-86d2-4730-b67d-bd454577aeee
 platform: android
-minsdk: 9.0.0
+minsdk: 12.7.0
 respackage: com.google.android.gms

--- a/android/platform/android/res/layout/ti_map.xml
+++ b/android/platform/android/res/layout/ti_map.xml
@@ -2,5 +2,6 @@
 <androidx.fragment.app.FragmentContainerView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/fragment_container_view"
+    android:importantForAccessibility="noHideDescendants"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/android/platform/android/res/layout/ti_map_raw.xml
+++ b/android/platform/android/res/layout/ti_map_raw.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.gms.maps.MapView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:map="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/lite_raw_map"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    map:liteMode="true" />
+    android:importantForAccessibility="noHideDescendants">
+
+    <com.google.android.gms.maps.MapView
+        android:id="@+id/lite_raw_map"
+        android:importantForAccessibility="noHideDescendants"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        map:liteMode="true" />
+</FrameLayout>

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -16,13 +16,14 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.location.Location;
 import android.os.Build;
-import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
+
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.Fragment;
+
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -54,16 +55,13 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
-import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiRHelper;
-import org.appcelerator.titanium.view.TiUIFragment;
 import org.appcelerator.titanium.view.TiUIView;
-import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -120,7 +118,8 @@ public class TiUIMapView extends TiUIView
 			var inflater = activity.getLayoutInflater();
 			var view = inflater.inflate(TiRHelper.getResource(rawMap ? "layout.ti_map_raw" : "layout.ti_map"), null);
 			if (rawMap) {
-				mapView = (MapView) view;
+				mapView = view.findViewById(TiRHelper.getResource("id.lite_raw_map"));
+				handleAccessibility();
 			}
 			setNativeView(view);
 		} catch (TiRHelper.ResourceNotFoundException e) {
@@ -152,7 +151,44 @@ public class TiUIMapView extends TiUIView
 						.commit();
 			}
 
+			handleAccessibility();
 			mapFragment.getMapAsync(this);
+		}
+	}
+
+
+	/**
+     * Crash fix: https://issuetracker.google.com/u/1/issues/457601635
+     *
+	 * Note: Though we already disable the accessibility in module's layout XML file,
+     * this will guard us against any hidden accessibility modifications at run time.
+     */
+	private void handleAccessibility() {
+		try {
+			if (mapView != null) {
+				mapView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+
+				// Disable for parent also.
+				ViewParent viewParent = mapView.getParent();
+				if (viewParent != null) {
+					((View) viewParent).setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+				}
+			}
+
+			if (mapFragment != null) {
+				View fragmentView = mapFragment.getView();
+				if (fragmentView != null) {
+					fragmentView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+
+					// Disable for parent also.
+					ViewParent viewParent = fragmentView.getParent();
+					if (viewParent != null) {
+						((View) viewParent).setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+					}
+				}
+			}
+		} catch (Exception e) {
+			Log.d("TiUIMapView", "Failed to update the accessibility: " + e.getMessage());
 		}
 	}
 
@@ -234,6 +270,7 @@ public class TiUIMapView extends TiUIView
 			return;
 		}
 
+		handleAccessibility();
 		MapsInitializer.initialize(proxy.getActivity().getApplicationContext());
 
 		//A workaround for https://code.google.com/p/android/issues/detail?id=11676 pre Jelly Bean.

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -98,6 +98,7 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	{
 		super();
 		preloadRoutes = new ArrayList<RouteProxy>();
+		defaultValues.put(TiC.PROPERTY_ACCESSIBILITY_HIDDEN, true);
 		defaultValues.put(MapModule.PROPERTY_COMPASS_ENABLED, true);
 		defaultValues.put(MapModule.PROPERTY_SCROLL_ENABLED, true);
 		defaultValues.put(MapModule.PROPERTY_ZOOM_ENABLED, true);


### PR DESCRIPTION
This PR disables the accessibility on the module completely to avoid this [Crash Issue](https://issuetracker.google.com/u/1/issues/457601635) outage.

Next Step: Once the issue is stable, we can modify the module to do it based on a property, or perhaps use the latest module version in upstream repo.